### PR TITLE
added interactive argument to process mode

### DIFF
--- a/TotalSegmentator/TotalSegmentator.py
+++ b/TotalSegmentator/TotalSegmentator.py
@@ -898,9 +898,9 @@ class TotalSegmentatorLogic(ScriptedLoadableModuleLogic):
             import ctk
             import qt
             mbox = ctk.ctkMessageBox(slicer.util.mainWindow())
-            mbox.text = "No GPU is detected. Switch to 'fast' mode to get low-resolution result in a few minutes or compute full-resolution result in up to an hour?"
+            mbox.text = "No GPU is detected. Switch to 'fast' mode to get low-resolution result in a few minutes or compute full-resolution result which may take 5 to 50 minutes (depending on computer configuration)?"
             mbox.addButton("Fast (~2 minutes)", qt.QMessageBox.AcceptRole)
-            mbox.addButton("Full-resolution (~5-50 minutes depending on volume and computer specs)", qt.QMessageBox.RejectRole)
+            mbox.addButton("Full-resolution (~5 to 50 minutes)", qt.QMessageBox.RejectRole)
             # Windows 10 peek feature in taskbar shows all hidden but not destroyed windows
             # (after creating and closing a messagebox, hovering over the mouse on Slicer icon, moving up the
             # mouse to the peek thumbnail would show it again).


### PR DESCRIPTION
interactive argument = false by default to enable running from command line without warning popups about slow mode. interactive = true when running via GUI, retaining previous warning popups about slow mode. Also adjusted warning text time estimate