### PR TITLE
BUG: Fix failing to install optional dependencies during selective install

### DIFF
--- a/TotalSegmentator/TotalSegmentator.py
+++ b/TotalSegmentator/TotalSegmentator.py
@@ -689,10 +689,12 @@ class TotalSegmentatorLogic(ScriptedLoadableModuleLogic):
 
             match = False
             if not match:
-                # ruff ; extra == 'dev' -> rewrite to: ruff[extra]
-                match = re.match(r"([\S]+)[\s]*; extra == '([^']+)'", requirement)
+                # Rewrite optional depdendencies info returned by importlib.metadata.requires to be valid for pip_install:
+                # Requirement Original: ruff; extra == "dev"
+                # Requirement Rewritten: ruff
+                match = re.match(r"([\S]+)[\s]*; extra == \"([^\"]+)\"", requirement)
                 if match:
-                    requirement = f"{match.group(1)}[{match.group(2)}]"
+                    requirement = f"{match.group(1)}"
             if not match:
                 # nibabel >=2.3.0 -> rewrite to: nibabel>=2.3.0
                 match = re.match("([\S]+)[\s](.+)", requirement)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/44f2232e-633a-4115-8263-12e04b762f0c)

Traceback:
```
Traceback (most recent call last):
  File "C:\Users\butlej30383\AppData\Local\slicer.org\Slicer 5.6.2\bin\Python\slicer\util.py", line 3255, in tryWithErrorDisplay
    yield
  File "C:/Users/butlej30383/AppData/Local/slicer.org/Slicer 5.6.2/slicer.org/Extensions-32448/TotalSegmentator/lib/Slicer-5.6/qt-scripted-modules/TotalSegmentator.py", line 319, in onPackageUpgrade
    self.logic.setupPythonRequirements(upgrade=True)
  File "C:/Users/butlej30383/AppData/Local/slicer.org/Slicer 5.6.2/slicer.org/Extensions-32448/TotalSegmentator/lib/Slicer-5.6/qt-scripted-modules/TotalSegmentator.py", line 821, in setupPythonRequirements
    self.pipInstallSelective('nnunetv2', nnunetRequirement, packagesToSkip)
  File "C:/Users/butlej30383/AppData/Local/slicer.org/Slicer 5.6.2/slicer.org/Extensions-32448/TotalSegmentator/lib/Slicer-5.6/qt-scripted-modules/TotalSegmentator.py", line 706, in pipInstallSelective
    slicer.util.pip_install(requirement)
  File "C:\Users\butlej30383\AppData\Local\slicer.org\Slicer 5.6.2\bin\Python\slicer\util.py", line 3887, in pip_install
    _executePythonModule("pip", args)
  File "C:\Users\butlej30383\AppData\Local\slicer.org\Slicer 5.6.2\bin\Python\slicer\util.py", line 3848, in _executePythonModule
    logProcessOutput(proc)
  File "C:\Users\butlej30383\AppData\Local\slicer.org\Slicer 5.6.2\bin\Python\slicer\util.py", line 3814, in logProcessOutput
    raise CalledProcessError(retcode, proc.args, output=proc.stdout, stderr=proc.stderr)
subprocess.CalledProcessError: Command '['C:/Users/butlej30383/AppData/Local/slicer.org/Slicer 5.6.2/bin/../bin\\PythonSlicer.EXE', '-m', 'pip', 'install', 'black;extra', '==', 'dev']' returned non-zero exit status 2.

```

`importlib` finds the optional dependencies where nnUNet has optional dependencies (see [here](https://github.com/MIC-DKFZ/nnUNet/blob/v2.5.1/pyproject.toml#L84-L89
)) for dev usage for enforcing various linting rules. Although these don't need to be installed to run TotalSegmentator successfully, I've changed the code to continue to install all the optional dependencies when using the selective pip install action.
https://github.com/lassoan/SlicerTotalSegmentator/blob/3ca58b17db54b8f52ec5ac193a83d3d03e5ff4a2/TotalSegmentator/TotalSegmentator.py#L679-L681

cc: @lassoan 

------------------------------

This was originally brought up by @Keyn34 in https://github.com/Slicer/ExtensionsIndex/pull/2127#issuecomment-2523214057.

>  I also get an error while installing TotalSegmentator Extension for black;extra==dev. I did not investigate further, though.


